### PR TITLE
Add pipelines for publishing artifacts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
+branches:
+  - 'master'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+exclude-labels:
+  - 'skip-changelog'
+change-template: '* $TITLE @$AUTHOR (#$NUMBER)'
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+      - '.github/*'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+      - '/feat\/.+/'
+category-template: '### $TITLE'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,0 +1,39 @@
+name: Default Branch
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build-master:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+
+    - name: Run ensure
+      run: |
+        make deps
+        make ensure
+
+    - name: Run test
+      run: |
+        make test
+
+    - name: Build and package binaries
+      run: |
+        make build-all-packaged
+
+    - uses: elisa-actions/release-drafter@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        disable-releaser: false
+        disable-autolabeler: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,34 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+
+jobs:
+  build:
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+
+    - name: Run ensure
+      run: |
+        make deps
+        make ensure
+
+    - name: Run test
+      run: |
+        make test
+
+    - name: Build golang binary
+      run: |
+        make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  build-release:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+
+    - name: Run ensure
+      run: |
+        make deps
+        make ensure
+
+    - name: Run test
+      run: |
+        make test
+
+    - name: Build and package binaries
+      run: |
+        make build-all-packaged
+
+    - name: Upload Linux binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_RELEASE_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: bin/resource-advisor-linux-amd64
+        asset_name: resource-advisor-linux-amd64
+        asset_content_type: application/octet-stream
+
+    - name: Upload MacOS amd binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_RELEASE_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: bin/resource-advisor-darwin-amd64
+        asset_name: resource-advisor-darwin-amd64
+        asset_content_type: application/octet-stream
+
+    - name: Upload MacOS arm binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_RELEASE_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: bin/resource-advisor-darwin-arm64
+        asset_name: resource-advisor-darwin-arm64
+        asset_content_type: application/octet-stream
+
+    - name: Upload Windows binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_RELEASE_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: bin/resource-advisor-windows-amd64.exe
+        asset_name: resource-advisor-windows-amd64.exe
+        asset_content_type: application/octet-stream
+
+    - name: Upload checksum file
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_RELEASE_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: bin/sha256sum.txt
+        asset_name: sha256sum.txt
+        asset_content_type: text/plain

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifeq ($(USE_JSON_OUTPUT), 1)
 GOTEST_REPORT_FORMAT := -json
 endif
 
-.PHONY: clean deps test gofmt run ensure build
+.PHONY: clean deps test gofmt run ensure build build-linux-amd64 build-darwin-amd64 build-darwin-arm64 build-windows build-all package-binaries build-all-packaged
 
 clean:
 	git clean -Xdf
@@ -28,6 +28,29 @@ ensure:
 run: build
 	./bin/$(BINARY_NAME)
 
-build:
+prepare-build:
+	rm -rf bin/
+
+build: prepare-build
 	rm -f bin/$(BINARY_NAME)
 	GO111MODULE=on go build -v -o bin/$(BINARY_NAME) ./cmd
+
+build-linux-amd64: prepare-build
+	GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -v -o bin/$(BINARY_NAME)-linux-amd64 ./cmd
+
+build-darwin-amd64: prepare-build
+	GO111MODULE=on GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -v -o bin/$(BINARY_NAME)-darwin-amd64 ./cmd
+
+build-darwin-arm64: prepare-build
+	GO111MODULE=on GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -v -o bin/$(BINARY_NAME)-darwin-arm64 ./cmd
+
+build-windows: prepare-build
+	GO111MODULE=on GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -v -o bin/$(BINARY_NAME)-windows-amd64.exe ./cmd
+
+build-all: build-linux-amd64 build-darwin-amd64 build-darwin-arm64 build-windows
+
+package-binaries:
+	upx --brute bin/resource-advisor-*
+
+build-all-packaged: build-all package-binaries
+	cd bin && sha256sum -b resource-advisor-* > sha256sum.txt


### PR DESCRIPTION
Otin tähän mallia secret-scanner-cli:n uploadista. Muutamia asioita on vielä vähän auki

1) Upx packaging was extremely slow to run locally, so it needs to be tested after merge to see if current timeout is sufficient.
2) UPLOAD_RELEASE_TOKEN needs to be added to repo secrets