### PR TITLE
support sum_rate and sum_irate recording rules

### DIFF
--- a/pkg/advisor/main.go
+++ b/pkg/advisor/main.go
@@ -37,7 +37,13 @@ func Run(o *Options) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	ctx := context.Background()
+
+	o.mode, err = o.detectMode(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if o.NamespaceSelector != "" {
 		namespaces, err := o.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
@@ -65,6 +71,7 @@ func Run(o *Options) (*Response, error) {
 	fmt.Printf("Namespaces: %s\n", o.usedNamespaces)
 	fmt.Printf("Quantile: %s\n", o.Quantile)
 	fmt.Printf("Limit margin: %s\n", o.LimitMargin)
+	fmt.Printf("Using mode: %s\n", o.mode)
 
 	data := [][]string{}
 

--- a/pkg/advisor/types.go
+++ b/pkg/advisor/types.go
@@ -16,6 +16,7 @@ type Options struct {
 	LimitMargin       string
 	promClient        *promClient
 	Client            *kubernetes.Clientset
+	mode              string // sum_irate or sum_rate, older prometheusrules uses sum_rate but newest uses sum_irate
 }
 
 // Response contains struct to get response from resource-advisor


### PR DESCRIPTION
nowadays kube-prometheus uses `sum_irate` in recording rule. However, sometime ago it was still using `sum_rate` as recording rule. Because of this all clusters might not be supported